### PR TITLE
Matching the console output to the provided string

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -34,7 +34,7 @@ Hopefully, this helps you to start learning and writing Clojure.
 
 ```clojure
 user=> (println "Hello, world!")
-hello, world
+Hello, world!
 nil
 
 


### PR DESCRIPTION
The output for `(println "Hello, world!")` should be "Hello, world!"
