### PR TITLE
Fix default value in map

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1512,7 +1512,7 @@ You get `nil` when key doesn't exist.
 
 ```clojure
 user=>  (get {:Apple "Mac" :Microsoft "Windows"} :Linux "Sorry, no Linux")
-nil
+"Sorry, no Linux"
 ```
 
 <br>


### PR DESCRIPTION
It should return "Sorry, no Linux", not `nil`.