### PR TITLE
Fix a mistake in the result of a "get" form

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1513,7 +1513,7 @@ You get `nil` when key doesn't exist.
 
 ```clojure
 user=>  (get {:Apple "Mac" :Microsoft "Windows"} :Linux "Sorry, no Linux")
-nil
+"Sorry, no Linux"
 ```
 
 <br>


### PR DESCRIPTION
Original:
user=>  (get {:Apple "Mac" :Microsoft "Windows"} :Linux "Sorry, no Linux")
nil

It should be:
user=>  (get {:Apple "Mac" :Microsoft "Windows"} :Linux "Sorry, no Linux")
"Sorry, no Linux"
