### PR TITLE
typo fix (in sec:first description section)

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1724,7 +1724,7 @@ user=> (first "string")
 <br>
 <br>
 
-Getting the first element in the vector.
+Getting the first element in the string.
 
 <br>
 <br>


### PR DESCRIPTION
"Getting the first element in the vector." => "Getting the first element in the string." on the second occurrence.